### PR TITLE
Fix "docpad is not defined" error on Docpad v6.66.0

### DIFF
--- a/src/thumbnails.plugin.coffee
+++ b/src/thumbnails.plugin.coffee
@@ -88,6 +88,8 @@ module.exports = (BasePlugin) ->
 
 		extendTemplateData: ({templateData}) ->
 
+			#Prepare
+			docpad = @docpad
 			me = @
 			config = @config
 
@@ -185,6 +187,8 @@ module.exports = (BasePlugin) ->
 
 		writeAfter: (opts,next) ->
 
+			#Prepare
+			docpad = @docpad
 			me = @
 			config = @config
 			failures = 0
@@ -241,6 +245,10 @@ module.exports = (BasePlugin) ->
 			@
 
 		generateAfter: ->
+
+			#Prepare
+			docpad = @docpad
+			
 			docpad.log 'debug', 'thumbnails: generateAfter'
 			@thumbnailsToGenerate = {}
 			@thumbnailsToGenerateLength = 0


### PR DESCRIPTION
Due to recent changes to Docpad (v6.66.0), thumbnail plugin stopped working giving the following error:

```
warning: Something went wrong while rendering: post.html.coffee
ReferenceError: docpad is not defined
  at Object.templateData.getThumbnail (/home/angel/Workspace/UnivUnix-RPi/node_modules/docpad-plugin-thumbnails/out/thumbnails.plugin.js:107:9)
```

To fix this error, I added the missing reference.

Regards.
