### PR TITLE
Resize images sychnoriously

### DIFF
--- a/src/thumbnails.plugin.coffee
+++ b/src/thumbnails.plugin.coffee
@@ -239,7 +239,7 @@ module.exports = (BasePlugin) ->
 						return complete()
 					)
 
-			tasks.async()
+			tasks.sync()
 
 			# Chain
 			@


### PR DESCRIPTION
If you use async and there are many images to resize this easily breaks almost any system.
